### PR TITLE
[iOS] Don't let anonymous to be a part of the game

### DIFF
--- a/iOS/RealmPop/Base.lproj/Main.storyboard
+++ b/iOS/RealmPop/Base.lproj/Main.storyboard
@@ -57,7 +57,7 @@
                                         <fontDescription key="fontDescription" name="PressStart2P" family="Press Start 2P" pointSize="17"/>
                                         <state key="normal" title="Enter"/>
                                         <connections>
-                                            <segue destination="BYZ-38-t0r" kind="show" id="6aB-f3-daf"/>
+                                            <segue destination="BYZ-38-t0r" kind="show" identifier="ShowGameRoom" id="6aB-f3-daf"/>
                                         </connections>
                                     </button>
                                 </subviews>

--- a/iOS/RealmPop/Player.swift
+++ b/iOS/RealmPop/Player.swift
@@ -10,7 +10,7 @@ import RealmSwift
 
 class Player: Object {
     dynamic var id = UUID().uuidString
-    dynamic var name = "Anonymous"
+    dynamic var name = ""
 
     dynamic var available = false
     dynamic var challenger: Player?

--- a/iOS/RealmPop/PreGameViewController.swift
+++ b/iOS/RealmPop/PreGameViewController.swift
@@ -30,6 +30,16 @@ class PreGameRoomViewController: UIViewController {
         super.viewWillAppear(animated)
         me.resetState()
     }
+
+    override func shouldPerformSegue(withIdentifier identifier: String, sender: Any?) -> Bool {
+        switch identifier {
+        case "ShowGameRoom":
+            return playerName.text?.isEmpty == false
+        default:
+            return true
+        }
+    }
+
 }
 
 extension PreGameRoomViewController: UITextFieldDelegate {


### PR DESCRIPTION
Using the default username will make a lot of duplicated player, I think it's better to force the users specify player name manually before the game.

/c @icanzilb 